### PR TITLE
fix: add fetch timeout to prevent blank blog page on direct URL — closes #416

### DIFF
--- a/apps/web-e2e/global-setup.ts
+++ b/apps/web-e2e/global-setup.ts
@@ -1,0 +1,32 @@
+import type { FullConfig } from "@playwright/test";
+
+/**
+ * Warms up the Vercel preview deployment before running E2E tests.
+ * Cold serverless functions can take 10-30s on first request, causing
+ * test timeouts when tests go directly to SSR-rendered pages.
+ */
+async function globalSetup(config: FullConfig) {
+  const baseURL =
+    config.projects[0]?.use?.baseURL ||
+    process.env.PLAYWRIGHT_BASE_URL ||
+    "http://localhost:3000";
+
+  const headers: Record<string, string> = {};
+  if (process.env.VERCEL_AUTOMATION_BYPASS_SECRET) {
+    headers["x-vercel-protection-bypass"] =
+      process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  }
+
+  const warmupUrls = ["/", "/blog"];
+
+  for (const url of warmupUrls) {
+    try {
+      const response = await fetch(`${baseURL}${url}`, { headers });
+      console.log(`[warmup] ${url} → ${response.status}`);
+    } catch (error) {
+      console.warn(`[warmup] ${url} failed:`, error);
+    }
+  }
+}
+
+export default globalSetup;

--- a/apps/web-e2e/global-setup.ts
+++ b/apps/web-e2e/global-setup.ts
@@ -4,6 +4,9 @@ import type { FullConfig } from "@playwright/test";
  * Warms up the Vercel preview deployment before running E2E tests.
  * Cold serverless functions can take 10-30s on first request, causing
  * test timeouts when tests go directly to SSR-rendered pages.
+ *
+ * Retries each URL up to 3 times to ensure the serverless function is
+ * fully warmed and returns real content (not a 0-byte cached page).
  */
 async function globalSetup(config: FullConfig) {
   const baseURL =
@@ -18,13 +21,30 @@ async function globalSetup(config: FullConfig) {
   }
 
   const warmupUrls = ["/", "/blog"];
+  const maxRetries = 3;
+  const retryDelay = 5_000;
 
   for (const url of warmupUrls) {
-    try {
-      const response = await fetch(`${baseURL}${url}`, { headers });
-      console.log(`[warmup] ${url} → ${response.status}`);
-    } catch (error) {
-      console.warn(`[warmup] ${url} failed:`, error);
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      try {
+        const response = await fetch(`${baseURL}${url}`, {
+          headers,
+          signal: AbortSignal.timeout(30_000),
+        });
+        const body = await response.text();
+        console.log(
+          `[warmup] ${url} → ${response.status} (${body.length} bytes, attempt ${attempt})`,
+        );
+        if (response.ok && body.length > 100) break;
+        console.warn(
+          `[warmup] ${url} returned insufficient content, retrying...`,
+        );
+      } catch (error) {
+        console.warn(`[warmup] ${url} attempt ${attempt} failed:`, error);
+      }
+      if (attempt < maxRetries) {
+        await new Promise((r) => setTimeout(r, retryDelay));
+      }
     }
   }
 }

--- a/apps/web-e2e/global-setup.ts
+++ b/apps/web-e2e/global-setup.ts
@@ -22,7 +22,7 @@ async function globalSetup(config: FullConfig) {
 
   const warmupUrls = ["/", "/blog"];
   const maxRetries = 3;
-  const retryDelay = 5_000;
+  const retryDelay = 5000;
 
   for (const url of warmupUrls) {
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
@@ -33,11 +33,11 @@ async function globalSetup(config: FullConfig) {
         });
         const body = await response.text();
         console.log(
-          `[warmup] ${url} → ${response.status} (${body.length} bytes, attempt ${attempt})`,
+          `[warmup] ${url} → ${response.status} (${body.length} bytes, attempt ${attempt})`
         );
         if (response.ok && body.length > 100) break;
         console.warn(
-          `[warmup] ${url} returned insufficient content, retrying...`,
+          `[warmup] ${url} returned insufficient content, retrying...`
         );
       } catch (error) {
         console.warn(`[warmup] ${url} attempt ${attempt} failed:`, error);

--- a/apps/web-e2e/playwright.config.ts
+++ b/apps/web-e2e/playwright.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
+  globalSetup: "./global-setup.ts",
   testDir: "./tests",
+  timeout: process.env.CI ? 60_000 : 30_000,
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/apps/web/src/lib/sanity.ts
+++ b/apps/web/src/lib/sanity.ts
@@ -22,7 +22,10 @@ async function sanityFetch<T>(
   if (preview && process.env.SANITY_API_TOKEN) {
     headers.Authorization = `Bearer ${process.env.SANITY_API_TOKEN}`;
   }
-  const res = await fetch(url.toString(), { headers });
+  const res = await fetch(url.toString(), {
+    headers,
+    signal: AbortSignal.timeout(10_000),
+  });
   if (!res.ok) {
     throw new Error(`Sanity query failed: ${res.status} ${res.statusText}`);
   }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -13,7 +13,9 @@ const SANITY_CDN_URL = `https://${SANITY_PROJECT_ID}.apicdn.sanity.io/v${SANITY_
 async function sanityQuery<T>(query: string): Promise<T> {
   const url = new URL(SANITY_CDN_URL);
   url.searchParams.set("query", query);
-  const res = await fetch(url.toString());
+  const res = await fetch(url.toString(), {
+    signal: AbortSignal.timeout(10_000),
+  });
   if (!res.ok) {
     throw new Error(
       `Sanity query failed during prerender route enumeration: ${res.status} ${res.statusText}`


### PR DESCRIPTION
## Problem

The blog page (`/blog`) returns a blank page (0 bytes) when accessed directly via URL, while CSR navigation from the homepage works fine.

**Root cause**: During production build, the Sanity fetch has no timeout. If the CDN is slow or hangs, the prerender produces a 0-byte HTML file. With `failOnError: false`, this empty file gets deployed to Vercel and cached indefinitely.

Evidence from production:
```
curl -sI https://opticasuarezjaen.es/blog
content-length: 0
x-vercel-cache: HIT
age: 432228
```

## Solution

1. **Fetch timeout**: Added `AbortSignal.timeout(10_000)` to all Sanity fetch calls:
   - `apps/web/src/lib/sanity.ts` — runtime `sanityFetch`
   - `apps/web/vite.config.ts` — build-time `sanityQuery` for route enumeration

2. **E2E warmup** (pre-existing fix): Added Playwright `globalSetup` to warm up Vercel preview deployments before tests run, preventing cold-start timeouts.

## Changes

- **apps/web/src/lib/sanity.ts**: 10s fetch timeout
- **apps/web/vite.config.ts**: 10s fetch timeout for prerender queries
- **apps/web-e2e/global-setup.ts**: New — deployment warmup before E2E
- **apps/web-e2e/playwright.config.ts**: globalSetup + 60s CI timeout

## Note

The cached 0-byte response on production will be replaced once a new deploy goes out. A Vercel redeploy of main after merging this PR will fix the live site.

## Deployment Workflow Summary

| Step | Status | Details |
|------|--------|---------|
| **Infrastructure Changes** | ⏭️ Skipped | Terraform plan/apply |
| **Deploy to Preview** | ✅ Applied | [Preview](https://opticasuarez-web-r9nbmjhbm-juanpeichs-projects.vercel.app) |
| **E2E Tests** | ✅ Applied | Playwright tests against preview |

---